### PR TITLE
chore: update black in pre-commit config to avoid click import error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     hooks:
       - id: isort
   - repo: https://github.com/ambv/black
-    rev: 21.5b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8


### PR DESCRIPTION
- Pre-commit CI recently added - [pre-commit.ci](https://pre-commit.ci/)
- Run fails, perhaps due to old version of black and incompatibility with version of click used in runner by pre-commit CI

![image](https://user-images.githubusercontent.com/61157247/188306215-668024e0-d0e2-49b1-9ef6-ec239483306b.png)
